### PR TITLE
Fixed error with brushes not showing in editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <meta name="twitter:card" content="summary_large_image" />
 
     <link rel="stylesheet" href="main.css" />
-    <script src="https://cdn.jsdelivr.net/npm/p5@latest/lib/p5.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/p5@1.11.5/lib/p5.min.js"></script>
     <script src="https://unpkg.com/hydra-synth"></script>
   </head>
   <body>


### PR DESCRIPTION
### Fixed error with brushes not showing in editor by setting p5 library version to 1.11.5.

Fix for #4 

With the latest update of the p5 library to the major version 2, there seem to be breaking changes which are causing that the brushes are not appearing in the editor.

The error on the console reads like this:

```
script.js:374 Uncaught (in promise) TypeError: element.touchStarted is not a function
    at addTouchListeners (script.js:374:11)
    at script.js:916:31
    at Array.forEach (<anonymous>)
    at buildGUI (script.js:916:11)
    at setup (script.js:326:3)
    at #F (p5.min.js:1:404597)
    at async #S (p5.min.js:1:404298)
```

I'm currently not aware about all the details of the p5 library and how to refactor the code in order to be compatible with the latest updates of the library, but setting the fixed version to 1.11.5 could fix the issue.